### PR TITLE
chore(ci): Include linting step in build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,9 +12,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Lint
-      run:
-        - cargo fmt --all --verbose
-        - cargo clippy --all --verbose
-        - cargo check --all --verbose
+      run: cargo fmt --all --verbose && cargo clippy --all --verbose && cargo check --all --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,5 +11,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
+    - name: Lint
+      run:
+        - cargo fmt --all --verbose
+        - cargo clippy --all --verbose
+        - cargo check --all --verbose
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
The linting is an important tool for code quality this makes sure it is correct